### PR TITLE
[WIP] qemu: snp-latest + vfio-user version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,8 @@
           spdk-libvfio-user = let pkgs = mic92pkgs; in pkgs.callPackage ./nix/spdk-libvfio-user.nix { inherit pkgs; };
           spdk = let pkgs = mic92pkgs; spdk-libvfio-user = selfpkgs.spdk-libvfio-user; in pkgs.callPackage ./nix/spdk.nix { inherit pkgs; inherit spdk-libvfio-user; };
 
-          qemu-amd-sev-snp = let pkgs = stablepkgs; in pkgs.callPackage ./nix/qemu-amd-sev-snp.nix { inherit pkgs; };
+          #qemu-amd-sev-snp = let pkgs = stablepkgs; in pkgs.callPackage ./nix/qemu-amd-sev-snp.nix { inherit pkgs; };
+          qemu-amd-sev-snp = pkgs.callPackage ./nix/qemu-amd-sev-snp.nix { inherit pkgs; };
           ovmf-amd-sev-snp = pkgs.callPackage ./nix/ovmf-amd-sev-snp.nix { inherit pkgs; };
           guest-image = make-disk-image
           {

--- a/nix/meson.patch
+++ b/nix/meson.patch
@@ -1,0 +1,15 @@
+diff --git a/meson.build b/meson.build
+index 98e68ef0b1..a3f1203cf3 100644
+--- a/meson.build
++++ b/meson.build
+@@ -3039,8 +3039,8 @@ endif
+ 
+ libvfio_user_dep = not_found
+ if have_system and vfio_user_server_allowed
+-  libvfio_user_proj = subproject('libvfio-user', required: true)
+-  libvfio_user_dep = libvfio_user_proj.get_variable('libvfio_user_dep')
++  # libvfio_user_proj = dependency('libvfio-user', required: true)
++  libvfio_user_dep = dependency('libvfio-user', required: true) # libvfio_user_proj.get_variable('libvfio_user_dep')
+ endif
+ 
+ fdt = not_found

--- a/nix/qemu-amd-sev-snp.nix
+++ b/nix/qemu-amd-sev-snp.nix
@@ -1,17 +1,93 @@
-{ pkgs }:
+{
+  pkgs
+}:
 
 with pkgs;
 qemu_full.overrideAttrs
 (
-  new: old:
+  new: old: rec
   {
-    src = fetchFromGitHub
-    {
-      owner = "AMDESE";
-      repo = "qemu";
-      rev = "94bec6ae7a81872ca0df2655dac18b2dea8c3090";
-      sha256 = "inX1Di5vP4c14E7nuQG8KigAZ2WyGQdud7+K83R4rrg=";
+    #when updating qemu, sync these with what is specified in qemu/subprojects/*.wrap
+    libvfio-user-src = pkgs.fetchFromGitLab {
+      owner = "qemu-project";
+      repo = "libvfio-user";
+      rev = "0b28d205572c80b568a1003db2c8f37ca333e4d7"; # upstream master 09.06.2022
+      hash = "sha256-V05nnJbz8Us28N7nXvQYbj66LO4WbVBm6EO+sCjhhG8=";
       fetchSubmodules = true;
     };
+    dtc-src = pkgs.fetchFromGitLab {
+      owner = "qemu-project";
+      repo = "dtc";
+      rev = "b6910bec11614980a21e46fbccc35934b671bd81";
+      hash = "sha256-gx9LG3U9etWhPxm7Ox7rOu9X5272qGeHqZtOe68zFs4=";
+      fetchSubmodules = true;
+    };
+    keycodemapdb-src = pkgs.fetchFromGitLab {
+      owner = "qemu-project";
+      repo = "keycodemapdb";
+      rev = "f5772a62ec52591ff6870b7e8ef32482371f22c6";
+      hash = "sha256-EQrnBAXQhllbVCHpOsgREzYGncMUPEIoWFGnjo+hrH4=";
+      fetchSubmodules = true;
+    };
+    bsf3-src = pkgs.fetchFromGitLab {
+      owner = "qemu-project";
+      repo = "berkeley-softfloat-3";
+      rev = "b64af41c3276f97f0e181920400ee056b9c88037";
+      hash = "sha256-Yflpx+mjU8mD5biClNpdmon24EHg4aWBZszbOur5VEA=";
+      fetchSubmodules = true;
+    };
+    btf3-src = pkgs.fetchFromGitLab {
+      owner = "qemu-project";
+      repo = "berkeley-testfloat-3";
+      rev = "40619cbb3bf32872df8c53cc457039229428a263";
+      hash = "sha256-EBz1uYnjehCtJqrSFzERH23N5ELZU3gGM26JnsGFcWg=";
+      fetchSubmodules = true;
+    };
+
+    # emulate meson subproject dependency management
+    postUnpack = ''
+      cp -r ${libvfio-user-src} $sourceRoot/subprojects/libvfio-user
+      chmod -R u+w $sourceRoot/subprojects/libvfio-user
+
+      cp -r ${dtc-src} $sourceRoot/subprojects/dtc
+      chmod -R u+w $sourceRoot/subprojects/dtc
+
+      cp -r ${keycodemapdb-src} $sourceRoot/subprojects/keycodemapdb
+      chmod -R u+w $sourceRoot/subprojects/keycodemapdb
+
+      cp -r ${bsf3-src} $sourceRoot/subprojects/berkeley-softfloat-3
+      chmod -R u+w $sourceRoot/subprojects/berkeley-softfloat-3
+      cp $sourceRoot/subprojects/packagefiles/berkeley-softfloat-3/* $sourceRoot/subprojects/berkeley-softfloat-3
+
+      cp -r ${btf3-src} $sourceRoot/subprojects/berkeley-testfloat-3
+      chmod -R u+w $sourceRoot/subprojects/berkeley-testfloat-3
+      cp $sourceRoot/subprojects/packagefiles/berkeley-testfloat-3/* $sourceRoot/subprojects/berkeley-testfloat-3
+    '';
+
+
+    src = fetchFromGitHub
+    {
+      owner = "mmisono";
+      repo = "qemu";
+      rev = "92d08ef30fead8b4b1f0bc4c3134de62f25b43ba";
+      sha256 = "sha256-a4fblPvCnoxPAkJ37To04J3B5Ttk4fhIfNxr7Sj0NFs=";
+      fetchSubmodules = true;
+    };
+    buildInputs = old.buildInputs ++ [
+      libndctl
+    ];
+    nativeBuildInputs = old.nativeBuildInputs ++ [
+      json_c
+      cmocka
+      meson
+      ninja
+      pkg-config
+      git
+    ];
+    configureFlags = old.configureFlags ++ [
+      "--enable-vfio-user-server"
+      "--target-list=x86_64-softmmu"
+      "--enable-multiprocess" # from https://github.com/nutanix/libvfio-user/blob/master/docs/spdk.md
+    ];
   }
 )


### PR DESCRIPTION
Add QEMU that supports snp + vfio-user.

The qemu is https://github.com/mmisono/qemu/tree/vfio-user-snp-latest. The repository merged https://github.com/AMDESE/qemu/tree/snp-latest on top of https://github.com/oracle/qemu/tree/vfio-user-p3.1

This almost works but the compilation fails. It seems Oracle's version qemu fetches livfio-user repository during the build process but that is not allowed as nix build run in a sandboxed environment. In my understanding, first we need to nixify libvfio-user and make qemu to use it.

```

error: builder for '/nix/store/r0arbq6npx7dhc8x8hixqgz7k8rpb06b-qemu-8.1.2.drv' failed with exit code 1;
       last 25 log lines:
       > Header "getopt.h" has symbol "optreset" : NO
       > Header "netinet/in.h" has symbol "IPPROTO_MPTCP" : YES
       > Checking whether type "struct sigevent" has member "sigev_notify_thread_id" : NO
       > Checking whether type "struct stat" has member "st_atim" : YES
       > Checking whether type "struct blk_zone" has member "capacity" : YES
       > Checking for type "struct iovec" : YES
       > Checking for type "struct utmpx" : YES
       > Checking for type "struct mmsghdr" : YES
       > Header "linux/vm_sockets.h" has symbol "AF_VSOCK" : YES
       > Program scripts/minikconf.py found: YES (/build/source/build/pyvenv/bin/python3 /build/source/scripts/minikconf.py)
       > Configuring x86_64-softmmu-config-target.h using configuration
       > Configuring x86_64-softmmu-config-devices.mak with command
       > Reading depfile: /build/source/build/meson-private/x86_64-softmmu-config-devices.mak.d
       > Configuring x86_64-softmmu-config-devices.h using configuration
       > Program scripts/make-config-poison.sh found: YES (/build/source/scripts/make-config-poison.sh)
       > Run-time dependency capstone found: YES 4.0.2
       > Initialized empty Git repository in /build/source/subprojects/libvfio-user/.git/
       > fatal: unable to access 'https://gitlab.com/qemu-project/libvfio-user.git/': Could not resolve host: gitlab.com
       >
       > ../meson.build:3042:22: ERROR: Git command failed: ['/nix/store/zcpq1fivdd131gshg58m4cyq7fwqr3j8-git-2.42.0/bin/git', 'fetch', '--depth', '1', 'origin', '0b28d205572c80b568a1003db2c8f37ca333e4d7']
       >
       > A full log can be found at /build/source/build/meson-logs/meson-log.txt
       >
       > ERROR: meson setup failed
       >
       For full logs, run 'nix log /nix/store/r0arbq6npx7dhc8x8hixqgz7k8rpb06b-qemu-8.1.2.drv'.
error: 1 dependencies of derivation '/nix/store/xpx1r5mg3pcj9sy8v18xh9c2fcb0ha9p-benchmark-devshell-env.drv' failed to build
```