### PR TITLE
task: Run VM with virtio-blk backed by a file

### DIFF
--- a/tasks/run.py
+++ b/tasks/run.py
@@ -91,11 +91,12 @@ def build_benchmark_qemu_cmd(
         c: Any,
         num_mem_gb: int = DEFAULT_NUM_MEM_GB,
         num_cpus: int = DEFAULT_NUM_CPUS,
-        rebuild_image: bool = False
+        rebuild_image: bool = False,
+        port: int = DEFAULT_SSH_FORWARD_PORT
         ):
     base_cmd = build_base_qemu_cmd(
             c,
-            DEFAULT_SSH_FORWARD_PORT,
+            port,
             num_mem_gb=num_mem_gb,
             num_cpus=num_cpus
             )
@@ -115,13 +116,15 @@ def build_sev_qemu_cmd(
         c: Any,
         num_mem_gb: int = DEFAULT_NUM_MEM_GB,
         num_cpus: int = DEFAULT_NUM_CPUS,
-        rebuild_image: bool = False
+        rebuild_image: bool = False,
+        port: int = DEFAULT_SSH_FORWARD_PORT
         ):
     base_cmd = build_benchmark_qemu_cmd(
             c,
             num_mem_gb=num_mem_gb,
             num_cpus=num_cpus,
-            rebuild_image=rebuild_image
+            rebuild_image=rebuild_image,
+            port=port
             )
 
     return f"{base_cmd} " \
@@ -140,6 +143,15 @@ def add_virtio_blk_nvme_to_qemu_cmd(
 
     return f"{base_cmd} " \
         f"-blockdev node-name=q1,driver=raw,file.driver=host_device,file.filename={nvme_path} " \
+        "-device virtio-blk,drive=q1"
+
+def add_virtio_blk_file_to_qemu_cmd(
+        base_cmd: str,
+        file_path: str,
+        ):
+
+    return f"{base_cmd} " \
+        f"-blockdev node-name=q1,driver=raw,file.driver=file,file.filename={file_path} " \
         "-device virtio-blk,drive=q1"
 
 def build_debug_poll_qemu_cmd(
@@ -256,6 +268,37 @@ def run_sev_virtio_blk_qemu(
             )
     qemu_cmd: str = add_virtio_blk_nvme_to_qemu_cmd(
             base_cmd=base_cmd
+            )
+    print_and_sudo(c, qemu_cmd, pty=True)
+
+@task(help={
+    'num_mem_gb': "Number of GBs of memory",
+    'num_cpus': "Number of CPUs",
+    'rebuild_image': "Rebuild nixos image (also recompiles kernel- takes a while)",
+    'file_path': "Path to file to use as virtio-blk device",
+    'port': "SSH port to use",
+    })
+def run_sev_virtio_blk_file_qemu(
+        c: Any,
+        file_path: str,
+        num_mem_gb: int = DEFAULT_NUM_MEM_GB,
+        num_cpus: int = DEFAULT_NUM_CPUS,
+        rebuild_image: bool = False,
+        port: int = DEFAULT_SSH_FORWARD_PORT
+        ) -> None:
+    """
+    Run Qemu SEV guest with virtio-blk-pci to NVMe SSD.
+    """
+    base_cmd = build_sev_qemu_cmd(
+            c,
+            num_mem_gb=num_mem_gb,
+            num_cpus=num_cpus,
+            rebuild_image=rebuild_image,
+            port=port
+            )
+    qemu_cmd: str = add_virtio_blk_file_to_qemu_cmd(
+            base_cmd=base_cmd,
+            file_path=file_path
             )
     print_and_sudo(c, qemu_cmd, pty=True)
 


### PR DESCRIPTION
Now we can run VM with virtio-blk backed by a file. e.g.,

```
mkdir -p /mnt/tmpfs
mount -t tmpfs -o size=1G tmpfs /mnt/tmpfs
dd if=/dev/zero of=/mnt/tmpfs/file1GB bs=1M count=1024
inv run.run-sev-virtio-blk-file-qemu --blk-file=/mnt/tmpfs/file1GB --port=3333
```