### PR TITLE
Update TDX

### DIFF
--- a/docs/software_version.md
+++ b/docs/software_version.md
@@ -41,11 +41,13 @@ Note
 - Intel summarizes TDX software information [here](https://github.com/intel/tdx/wiki/TDX-KVM).
 - Also, Canonical summarizes information on TDX on Ubuntu [here](https://github.com/canonical/tdx).
     - Using Ubuntu would make life easier for the most cases
+- Xeon 6 processors with E-cores require the newer [software stack](https://github.com/canonical/tdx/releases/tag/3.1) to successfully boot TDX VMs.
 
 ### Sotware version table
-| host kernel version | linux | ovmf | qemu |
-| ------------------- | ----- | -----| -----|
-| 6.8.0-rc1           | [kvm-upstream-next-20240122](https://github.com/mmisono/linux/tree/tdx-kvm-upstream-next-20240122) | [TDVF-20240105](https://github.com/mmisono/edk2/tree/TDVF-20240105) | [tdx-qemu-next-20231208](https://github.com/mmisono/qemu/tree/tdx-qemu-next-20231208) |
+| host kernel version | linux | ovmf | qemu | notes |
+| ------------------- | ----- | -----| -----| ----- |
+| 6.8.0-rc1           | [kvm-upstream-next-20240122](https://github.com/mmisono/linux/tree/tdx-kvm-upstream-next-20240122) | [TDVF-20240105](https://github.com/mmisono/edk2/tree/TDVF-20240105) | [tdx-qemu-next-20231208](https://github.com/mmisono/qemu/tree/tdx-qemu-next-20231208) |   |
+| 6.11.0              | [canonical-intel-6.11.0-1006.6](https://github.com/gierens/linux-tdx-canonical) | [TDVF-20240105-subhook-patch](https://github.com/gierens/edk2-staging/tree/tdvf-update-subhook) | [canonical-kobuk-tdx-9.0.2](https://github.com/gierens/qemu-tdx-canonical) | needed for Xeon 6E |
 
 ### Ubuntu 23.10
 - Software stack: https://github.com/canonical/tdx/tree/mantic-23.10

--- a/nix/ovmf-tdx.nix
+++ b/nix/ovmf-tdx.nix
@@ -3,11 +3,11 @@
 with pkgs;
 OVMF.fd.overrideAttrs (old: {
   src = fetchFromGitHub {
-    owner = "tianocore";
+    owner = "gierens";
     repo = "edk2-staging";
-    # branch "TDVF"
-    rev = "c229fca09ebc3ed300845e5346d59e196461c498";
-    sha256 = "sha256-LqeGrdor6t3aH6HwEPgOqyyd6UsFRjU8EwwN1MHsreo=";
+    # branch "tdvf-upddate-subhook"
+    rev = "97a91317bd5a16ee418307c3bef13c66addfc42d";
+    sha256 = "sha256-InJjSqggLhVJnY17RqxapXWqNcvnk7tR2HP2bPdv2Ec=";
     fetchSubmodules = true;
   };
   patches = (old.patches or [ ]) ++ [

--- a/nix/qemu-tdx.nix
+++ b/nix/qemu-tdx.nix
@@ -3,14 +3,11 @@
 with pkgs;
 qemu_full.overrideAttrs (new: old: {
   src = fetchFromGitHub {
-    owner = "intel-staging";
-    repo = "qemu-tdx";
-    # branch: tdx-qemu-upstream
-    #rev = "97d7eee4450ca607d36acd2bb1d6137d193687cc";
-    #sha256 = "sha256-XecX9ZpJCVCYjUwGAXuoJJl3bAVsG+a91hwugzWCrQI=";
-    # branch: tdx-qemu-next
-    rev = "7a97b8940d938d0d5740c0513c9acf0053c6cb85";
-    sha256 = "sha256-uH2XZlxTAwaVmlgiUCM8N95EpNIe3haAuy9opjAuW3o=";
+    owner = "gierens";
+    repo = "qemu-tdx-canonical";
+    # branch: master
+    rev = "1d4b179dc86bf1695f80175b2ea92d99bf2137b8";
+    sha256 = "sha256-eRKGiqK95jAzAYYk+oSS0vJ1UiMeN5FVTwDscMM1Ieg=";
     fetchSubmodules = true;
     postFetch = ''
       cd "$out"
@@ -38,6 +35,6 @@ qemu_full.overrideAttrs (new: old: {
   # no patch
   patches = [ ];
 
-  # NOTE: The compiled binary is wrapped. (gtkSuppor=false does not prevent wrapping. why?)
+  # NOTE: The compiled binary is wrapped. (gtkSupport=false does not prevent wrapping. why?)
   # The actual binary is ./result/bin/.qemu-system-x86_64-wrapped
 })


### PR DESCRIPTION
This updates ovmf-tdx and qemu-tdx to the more recent versions
matching the host kernel config on the chair servers.
